### PR TITLE
Fixed Express Router import in router.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ else {
     app.use(helmet())
     // Enable rate limiter.
     app.use(limiter)
-    // Enable handling of all requests via the router.js file.
+    // Enable handling of all requests via the router.ts file.
     app.use('/', router)
 
     // Run Express server and listen on port.

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,4 +1,4 @@
-import Router from 'express'
+import { Router } from 'express'
 import { r6_profiles } from './routes/r6/profiles'
 import { _404 } from './routes/404'
 import { Middleware } from './middleware/middleware'


### PR DESCRIPTION
When importing Express Router through `import Router from 'express'`, this actually imports the main Express module but named as Router. When an instance of this is created, it creates an instance of an Express application (which somehow still works, but probably isn't the desired intent).

Instead, we should import the `Router` module instead from Express by deconstructing the module and then create an instance of the router with `router = Router()`.

The changes have been made accordingly in the source code.